### PR TITLE
fix: add ability to use external inputRef

### DIFF
--- a/src/components/TextFieldChip/TextFieldChips.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.tsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton'
 import type { TextFieldProps } from '@mui/material/TextField'
 import { KEYBOARD_KEY, KEYBOARD_KEYCODE } from '@shared/constants/event'
 import { matchIsBoolean } from '@shared/helpers/boolean'
+import { matchIsObject } from '@shared/helpers/object'
 import { assocRefToPropRef } from '@shared/helpers/ref'
 import type {
   MuiChipsInputChip,
@@ -69,7 +70,7 @@ const TextFieldChips = React.forwardRef(
     const [inputValueUncontrolled, setInputValueUncontrolled] =
       React.useState<string>('')
     const [textError, setTextError] = React.useState<string>('')
-    const inputElRef = React.useRef<HTMLDivElement | null>(null)
+    const inputElRef = React.useRef<HTMLInputElement>()
     const isFocusingRef = React.useRef<boolean>(false)
     const isControlledRef = React.useRef(
       typeof inputValueControlled === 'string'
@@ -79,6 +80,7 @@ const TextFieldChips = React.forwardRef(
     >(null)
     const { onKeyDown, ...restInputProps } = inputProps || {}
     const { inputRef, ...restIInputProps } = InputProps || {}
+    const { inputRef: userInputRef } = props || {}
 
     const clearTextError = () => {
       setTextError('')
@@ -129,9 +131,17 @@ const TextFieldChips = React.forwardRef(
       isFocusingRef.current = false
     }
 
-    const handleRef = (ref: HTMLDivElement | null): void => {
-      // @ts-ignore
-      inputElRef.current = ref
+    const handleRef = (ref: HTMLInputElement): void => {
+      if (
+        userInputRef &&
+        matchIsObject(userInputRef) &&
+        'current' in userInputRef
+      ) {
+        ;(userInputRef as React.MutableRefObject<HTMLInputElement>).current =
+          ref
+      } else {
+        inputElRef.current = ref
+      }
       if (propRef) {
         assocRefToPropRef(ref, propRef)
       }
@@ -264,7 +274,13 @@ const TextFieldChips = React.forwardRef(
         updateChipIndexEditable(chipIndex)
       }
 
-      inputElRef.current?.focus()
+      if (userInputRef) {
+        ;(
+          userInputRef as React.MutableRefObject<HTMLInputElement>
+        ).current?.focus()
+      } else {
+        inputElRef.current?.focus()
+      }
     }
 
     const handleDeleteChip = (chipIndex: number) => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -28,6 +28,14 @@ describe('components/MuiChipsInput', () => {
     expect(screen.getByTitle('bar')).toBeTruthy()
   })
 
+  test('should accept users inputRef', () => {
+    const inputRef = React.createRef<HTMLInputElement>()
+
+    render(<MuiChipsInput inputRef={inputRef} inputValue="good dogo" />)
+    const input = screen.getByDisplayValue('good dogo')
+    expect(inputRef.current).toBe(input)
+  })
+
   test('should call onAddChip when new chip is added', async () => {
     const callbackOnAddChip = vi.fn(() => {})
     render(<MuiChipsInputControlled onAddChip={callbackOnAddChip} />)

--- a/src/shared/constants/event.ts
+++ b/src/shared/constants/event.ts
@@ -1,8 +1,8 @@
 export const KEYBOARD_KEY = {
   enter: 'Enter',
   backspace: 'Backspace'
-}
+} as const
 
 export const KEYBOARD_KEYCODE = {
   ime: 229
-}
+} as const


### PR DESCRIPTION
This PR makes the passed inputRef in `MuiChipsInput` bind with the input.

Since the component uses all MUI TextField props, it should use the passed inputRef if any.

closes: #19