### PR TITLE
Move required to TextField only

### DIFF
--- a/src/components/TextFieldChip/TextFieldChips.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.tsx
@@ -57,6 +57,7 @@ const TextFieldChips = React.forwardRef(
       hideClearAll,
       inputProps,
       size,
+      required,
       disableDeleteOnBackspace,
       disableEdition,
       className,
@@ -288,6 +289,7 @@ const TextFieldChips = React.forwardRef(
           ref={propRef}
           className={`MuiChipsInput-TextField ${className || ''}`}
           size={size}
+          required={required}
           placeholder="Type and press enter"
           onFocus={handleFocus}
           inputProps={{


### PR DESCRIPTION
Hello,

currently, the required prop got passed to the input itself.
This is not neccessary, as stated in the MUI docs, required has only to be set on the TextField.
Currently this causes a problem with forms, since setting the <input> element to required triggers browser validation (saying this field is required) and the input field itself is empty even chips are shown. This should fix this error.