### PR TITLE
feat: ✨ Adds addOnBlur behaviour (without breaking changes)

### DIFF
--- a/src/components/TextFieldChip/TextFieldChips.test.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.test.tsx
@@ -139,20 +139,15 @@ describe('components/TextFieldChips', () => {
   })
 
   test('should add chip on blur when addOnBlur', async () => {
-    const callbackOnInputChange = vi.fn(() => {})
+    const callbackOnAddChip = vi.fn(() => {})
     render(
-      <TextFieldChips
-        chips={['test']}
-        addOnBlur
-        onInputChange={callbackOnInputChange}
-      />
+      <TextFieldChips chips={[]} addOnBlur onAddChip={callbackOnAddChip} />
     )
 
-    expect(testUtils.getInputElement().value).toBe('')
     await testUtils.typeInInputElement('foo')
     fireEvent.click(document)
     expect(testUtils.getInputElement().value).toBe('')
-    expect(callbackOnInputChange).toHaveBeenCalledTimes(4)
+    expect(callbackOnAddChip).toHaveBeenCalledWith('foo')
   })
 
   test('should not clear input on blur when no clearInputOnBlur', async () => {

--- a/src/components/TextFieldChip/TextFieldChips.test.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.test.tsx
@@ -138,6 +138,23 @@ describe('components/TextFieldChips', () => {
     expect(callbackOnInputChange).toHaveBeenCalledWith('')
   })
 
+  test('should add chip on blur when addOnBlur', async () => {
+    const callbackOnInputChange = vi.fn(() => {})
+    render(
+      <TextFieldChips
+        chips={['test']}
+        addOnBlur
+        onInputChange={callbackOnInputChange}
+      />
+    )
+
+    expect(testUtils.getInputElement().value).toBe('')
+    await testUtils.typeInInputElement('foo')
+    fireEvent.click(document)
+    expect(testUtils.getInputElement().value).toBe('')
+    expect(callbackOnInputChange).toHaveBeenCalledTimes(4)
+  })
+
   test('should not clear input on blur when no clearInputOnBlur', async () => {
     const callbackOnInputChange = vi.fn(() => {})
     render(

--- a/src/components/TextFieldChip/TextFieldChips.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.tsx
@@ -175,26 +175,16 @@ const TextFieldChips = React.forwardRef(
         clearChipIndexEditable()
         clearInputValue()
       } else if (addOnBlur) {
-        const inputValueTrimed = inputValue.trim()
         if (inputValue.length > 0) {
-          if (inputValueTrimed.length === 0) {
+          const inputValueTrimmed = inputValue.trim()
+          if (inputValueTrimmed.length === 0) {
             clearInputValue()
           } else if (chipIndexEditable !== null) {
-            updateChip(inputValueTrimed, chipIndexEditable)
+            updateChip(inputValueTrimmed, chipIndexEditable)
           } else {
-            addChip(inputValueTrimed)
+            addChip(inputValueTrimmed)
           }
-        } else if (
-          inputValue.length === 0 &&
-          chips.length > 0 &&
-          !disableDeleteOnBackspace
-        ) {
-          const chipIndex = chips.length - 1
-          onDeleteChip?.(chipIndex)
-          if (chipIndexEditable === chipIndex) {
-            clearChipIndexEditable()
-          }
-        }
+        } 
       } else if (clearInputOnBlur) {
         clearInputValue()
       }

--- a/src/components/TextFieldChip/TextFieldChips.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.tsx
@@ -20,6 +20,7 @@ type TextFieldChipsProps = TextFieldProps & {
   onAddChip?: (chip: MuiChipsInputChip) => void
   onEditChip?: (chip: MuiChipsInputChip, chipIndex: number) => void
   clearInputOnBlur?: boolean
+  addOnBlur?: boolean
   hideClearAll?: boolean
   disableDeleteOnBackspace?: boolean
   addOnWhichKey?: string | string[]
@@ -51,6 +52,7 @@ const TextFieldChips = React.forwardRef(
       onInputChange,
       disabled,
       clearInputOnBlur,
+      addOnBlur,
       validate,
       error,
       helperText,
@@ -116,44 +118,19 @@ const TextFieldChips = React.forwardRef(
       updateInputValue(event.target.value)
     }
 
-    const handleClickAway = () => {
-      if (!isFocusingRef.current) {
-        return
-      }
-      if (chipIndexEditable !== null) {
-        clearChipIndexEditable()
-        clearInputValue()
-      } else if (clearInputOnBlur) {
-        clearInputValue()
-      }
-
-      isFocusingRef.current = false
-    }
-
-    const handleRef = (ref: HTMLDivElement | null): void => {
-      // @ts-ignore
-      inputElRef.current = ref
-      if (inputRefFromProp) {
-        assocRefToPropRef(ref, inputRefFromProp)
-      }
-      if (propRef) {
-        assocRefToPropRef(ref, propRef)
-      }
-    }
-
     const validationGuard = (
       chipValue: MuiChipsInputChip,
-      event: React.KeyboardEvent<HTMLInputElement>
+      event?: React.KeyboardEvent<HTMLInputElement>
     ) => {
       return (callback: () => void) => {
         if (typeof validate === 'function') {
           const validation = validate(chipValue)
           if (validation === false) {
-            event.preventDefault()
+            event?.preventDefault()
             return
           }
           if (!matchIsBoolean(validation) && validation.isError) {
-            event.preventDefault()
+            event?.preventDefault()
             setTextError(validation.textError)
             return
           }
@@ -165,7 +142,7 @@ const TextFieldChips = React.forwardRef(
     const updateChip = (
       chipValue: MuiChipsInputChip,
       chipIndex: number,
-      event: React.KeyboardEvent<HTMLInputElement>
+      event?: React.KeyboardEvent<HTMLInputElement>
     ) => {
       validationGuard(
         chipValue,
@@ -179,7 +156,7 @@ const TextFieldChips = React.forwardRef(
 
     const addChip = (
       chipValue: MuiChipsInputChip,
-      event: React.KeyboardEvent<HTMLInputElement>
+      event?: React.KeyboardEvent<HTMLInputElement>
     ) => {
       validationGuard(
         chipValue,
@@ -188,6 +165,51 @@ const TextFieldChips = React.forwardRef(
         onAddChip?.(inputValue.trim())
         clearInputValue()
       })
+    }
+
+    const handleClickAway = () => {
+      if (!isFocusingRef.current) {
+        return
+      }
+      if (chipIndexEditable !== null) {
+        clearChipIndexEditable()
+        clearInputValue()
+      } else if (addOnBlur) {
+        const inputValueTrimed = inputValue.trim()
+        if (inputValue.length > 0) {
+          if (inputValueTrimed.length === 0) {
+            clearInputValue()
+          } else if (chipIndexEditable !== null) {
+            updateChip(inputValueTrimed, chipIndexEditable)
+          } else {
+            addChip(inputValueTrimed)
+          }
+        } else if (
+          inputValue.length === 0 &&
+          chips.length > 0 &&
+          !disableDeleteOnBackspace
+        ) {
+          const chipIndex = chips.length - 1
+          onDeleteChip?.(chipIndex)
+          if (chipIndexEditable === chipIndex) {
+            clearChipIndexEditable()
+          }
+        }
+      } else if (clearInputOnBlur) {
+        clearInputValue()
+      }
+
+      isFocusingRef.current = false
+    }
+
+    const handleRef = (ref: HTMLDivElement | null): void => {
+      inputElRef.current = ref
+      if (inputRefFromProp) {
+        assocRefToPropRef(ref, inputRefFromProp)
+      }
+      if (propRef) {
+        assocRefToPropRef(ref, propRef)
+      }
     }
 
     const matchIsValidKeyToAdd = (eventKey: string, eventKeyCode: number) => {
@@ -351,6 +373,7 @@ const TextFieldChips = React.forwardRef(
 TextFieldChips.defaultProps = {
   onInputChange: () => {},
   clearInputOnBlur: false,
+  addOnBlur: false,
   hideClearAll: false,
   disableDeleteOnBackspace: false,
   disableEdition: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ const MuiChipsInput = React.forwardRef(
       disabled,
       validate,
       clearInputOnBlur,
+      addOnBlur,
       hideClearAll,
       disableDeleteOnBackspace,
       onEditChip,
@@ -83,6 +84,7 @@ const MuiChipsInput = React.forwardRef(
         renderChip={renderChip}
         onDeleteAllChips={handleDeleteAllChips}
         clearInputOnBlur={clearInputOnBlur}
+        addOnBlur={addOnBlur}
         disabled={disabled}
         disableEdition={disableEdition}
         validate={validate}
@@ -105,6 +107,7 @@ MuiChipsInput.defaultProps = {
   onEditChip: () => {},
   addOnWhichKey: KEYBOARD_KEY.enter,
   clearInputOnBlur: false,
+  addOnBlur: false,
   disableEdition: false,
   hideClearAll: false,
   disableDeleteOnBackspace: false,

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -38,7 +38,6 @@ export interface BaseMuiChipsInputProps {
     key: React.Key,
     ChipProps: MuiChipsInputChipProps
   ) => JSX.Element
-  clearInputOnBlur?: boolean
   hideClearAll?: boolean
   disableEdition?: boolean
   disableDeleteOnBackspace?: boolean
@@ -47,4 +46,21 @@ export interface BaseMuiChipsInputProps {
   ) => boolean | { isError: boolean; textError: string }
 }
 
-export type MuiChipsInputProps = TextFieldProps & BaseMuiChipsInputProps
+// Discriminated union which allows ClearOnBlur or AddOnBlur, but not both, or neither
+type ChipInputBlurBehavior =
+  | {
+      clearInputOnBlur: true
+      addOnBlur?: never
+    }
+  | {
+      clearInputOnBlur?: never
+      addOnBlur: true
+    }
+  | {
+      clearInputOnBlur?: false
+      addOnBlur?: false
+    }
+
+export type MuiChipsInputProps = TextFieldProps &
+  BaseMuiChipsInputProps &
+  ChipInputBlurBehavior


### PR DESCRIPTION
I went for a discriminated union here to prevent both addOnBlur and clearOnBlur can't both be true. Let me know if you'd prefer a different implementation