### PR TITLE
`Docs > API Reference` add `addOnWhichKey`

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -18,7 +18,7 @@ This article discusses the API and props of **MuiChipsInput**. Props are defined
 ## `addOnWhichKey`
 
 - Type: `string[]` | `string`
-- Default: `KEYBOARD_KEY.enter`
+- Default: `'Enter'`
 
 ```tsx
 <MuiChipsInput addOnWhichKey={[',', ' ', 'Enter']} />

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -15,6 +15,15 @@ This article discusses the API and props of **MuiChipsInput**. Props are defined
 <MuiChipsInput value={['foo', 'bar']} />
 ```
 
+## `addOnWhichKey`
+
+- Type: `string[]` | `string`
+- Default: `KEYBOARD_KEY.enter`
+
+```tsx
+<MuiChipsInput addOnWhichKey={[',', ' ', 'Enter']} />
+```
+
 ## `onChange`
 
 - Type: `(value: string[]) => void`


### PR DESCRIPTION
Added the description of the component's `addOnWhichKey` property in the `Docs > API Reference` as it was not there.
I noticed a typo in my previous Pull Request, so I am submitting a new Pull Request to correct it.

Reference:
#48