### PR TITLE
Added ability to change the order of chips by Drag&Drop

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -18,7 +18,7 @@ This article discusses the API and props of **MuiChipsInput**. Props are defined
 ## `addOnWhichKey`
 
 - Type: `string[]` | `string`
-- Default: `KEYBOARD_KEY.enter`
+- Default: `'Enter'`
 
 ```tsx
 <MuiChipsInput addOnWhichKey={[',', ' ', 'Enter']} />

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -15,6 +15,15 @@ This article discusses the API and props of **MuiChipsInput**. Props are defined
 <MuiChipsInput value={['foo', 'bar']} />
 ```
 
+## `addOnWhichKey`
+
+- Type: `string[]` | `string`
+- Default: `KEYBOARD_KEY.enter`
+
+```tsx
+<MuiChipsInput addOnWhichKey={[',', ' ', 'Enter']} />
+```
+
 ## `onChange`
 
 - Type: `(value: string[]) => void`

--- a/src/components/TextFieldChip/TextFieldChips.tsx
+++ b/src/components/TextFieldChip/TextFieldChips.tsx
@@ -18,6 +18,7 @@ import Styled from './TextFieldChips.styled'
 
 type TextFieldChipsProps = TextFieldProps & {
   chips: MuiChipsInputChip[]
+  chipsChange?: (chips: MuiChipsInputChip[]) => void
   onAddChip?: (chip: MuiChipsInputChip) => void
   onEditChip?: (chip: MuiChipsInputChip, chipIndex: number) => void
   clearInputOnBlur?: boolean
@@ -42,6 +43,7 @@ const TextFieldChips = React.forwardRef(
   (
     {
       chips,
+      chipsChange,
       onAddChip,
       onEditChip,
       onDeleteChip,
@@ -72,6 +74,9 @@ const TextFieldChips = React.forwardRef(
     const [inputValueUncontrolled, setInputValueUncontrolled] =
       React.useState<string>('')
     const [textError, setTextError] = React.useState<string>('')
+    const [draggedChipIndex, setDraggedChipIndex] = React.useState<
+      number | null
+    >(null)
     const inputElRef = React.useRef<HTMLDivElement | null>(null)
     const isFocusingRef = React.useRef<boolean>(false)
     const isControlledRef = React.useRef(
@@ -310,6 +315,27 @@ const TextFieldChips = React.forwardRef(
       }
     }
 
+    const handleDragStart = (index: number) => {
+      setDraggedChipIndex(index)
+    }
+
+    const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+    }
+
+    const handleDrop = (dropIndex: number) => {
+      if (draggedChipIndex === null || draggedChipIndex === dropIndex) {
+        return
+      }
+
+      const newChips = [...chips]
+      const [draggedChip] = newChips.splice(draggedChipIndex, 1)
+      newChips.splice(dropIndex, 0, draggedChip)
+
+      chipsChange?.(newChips)
+      setDraggedChipIndex(null)
+    }
+
     const hasAtLeastOneChip = chips.length > 0
 
     return (
@@ -351,7 +377,18 @@ const TextFieldChips = React.forwardRef(
                   return renderChip ? (
                     renderChip(Chip, key, ChipProps)
                   ) : (
-                    <Chip {...ChipProps} key={key} />
+                    <Chip
+                      {...ChipProps}
+                      key={key}
+                      draggable
+                      onDragStart={() => {
+                        handleDragStart(index)
+                      }}
+                      onDragOver={handleDragOver}
+                      onDrop={() => {
+                        handleDrop(index)
+                      }}
+                    />
                   )
                 })
               : null,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,9 +79,14 @@ const MuiChipsInput = React.forwardRef(
       onChange?.([])
     }
 
+    const chipsChange = (chips: MuiChipsInputChip[]) => {
+      onChange?.(chips)
+    }
+
     return (
       <TextFieldChips
         chips={value}
+        chipsChange={chipsChange}
         onAddChip={handleAddChip}
         onInputChange={onInputChange}
         disableDeleteOnBackspace={disableDeleteOnBackspace}


### PR DESCRIPTION
You can change the order of Chips through a drag-and-drop event listener.

## Demo Video
https://youtu.be/4TM7Deq8lOM

## Reference
#45 

## P.S.
This PR includes the PR from #50.