### PR TITLE
#52 issues fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   ],
   "main": "./dist/mui-chips-input.es.js",
   "types": "./dist/index.d.ts",
-  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
After looking into the code, I found out that the "type": "module" option in node_modules/mui-chips-input/package.json forces mui-chips-input to input the .js extension when using the import statement.

I have identified this issue and will request a PR as soon as possible. However, since I am not a contributor to the initial development of the module, I do not know the reason behind setting the "type": "module" option.

However, I don't know the exact reason why this option is set, so please judge whether it is right or wrong and merge or close this PR.

## Revision history
`"type": "module"` option deleted.

## Reference
#52 