### PR TITLE
#52 issues fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chips"
   ],
   "scripts": {
-    "build": "pnpm lint && pnpm test -- run && vite build",
+    "build": "pnpm lint && pnpm test -- run && vite build && find dist -name '*.js' -exec sed -i 's/from \"\\([^\"].*\\)\"/from \"\\1.js\"/g' {} +",
     "lint": "tsc && eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "pnpm lint -- --fix",
     "check-types": "attw --pack . --ignore-rules cjs-resolves-to-esm  -f json",


### PR DESCRIPTION
Due to the "type": "module" option, it is necessary to specify the extensions in import statements, but I have fixed the issue where the modules imported in the built mui-chips-input.es.js file do not have their extensions specified.

## Changed File
`package.json` - build option change

## Reference
#52 #53 