### PR TITLE
feat: added support for react 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^6.0.0",
         "@mui/material": "^6.0.0",
-        "@types/react": "^18.3.12",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "@types/react": "^19.0.0 || ^18.3.12",
+        "react": "^19.0.0 || ^18.3.1",
+        "react-dom": "^19.0.0 || ^18.3.1"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.0.0",
-    "@types/react": "^18.3.12",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "@types/react": "^19.0.0 || ^18.3.12",
+    "react": "^19.0.0 || ^18.3.1",
+    "react-dom": "^19.0.0 || ^18.3.1",
     "@mui/icons-material": "^6.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
This PR updates the mui-chips-input package.json to support React 19. It ensures compatibility with the latest React release while maintaining backward compatibility with previous version.